### PR TITLE
privs and env variable name matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,39 @@ cd data-ingestion
    - Download and ingest the property data
 
 
+## Make your API key Read Only
+
+The data ingestion section created a key with broader server privleges like creating indices and search template scripts.  You can further restrict that API key by editing the existing key's security privileges or making a new key with the following:
+
+```json
+{
+  "mcp_server_read_only": {
+    "cluster": [
+      "monitor"
+    ],
+    "indices": [
+      {
+        "names": [
+          "properties", "properties_raw"
+        ],
+        "privileges": [
+          "read",
+          "view_index_metadata"
+        ],
+        "allow_restricted_indices": false
+      }
+    ],
+    "applications": [],
+    "run_as": [],
+    "metadata": {},
+    "transient_metadata": {
+      "enabled": true
+    }
+  }
+}
+```
+
+
 ## Requirements
 
 - Python 3.x
@@ -104,10 +137,10 @@ The following environment variables need to be configured in `env_config.sh`:
 1. Clone the repository:
 ```bash
 git clone https://github.com/sunilemanjee/Elastic-Python-MCP-Server.git
-cd ELASTIC-PYTHON-MCP-SERVER
+cd Elastic-Python-MCP-Server
 ```
 
-2. Create and configure your environment variables:
+2. If you did not already in the data ingestion instructions, create and configure your environment variables:
 ```bash
 # Copy the template file
 cp env_config.template.sh env_config.sh

--- a/data-ingestion/README.md
+++ b/data-ingestion/README.md
@@ -40,19 +40,20 @@ data-ingestion/
 1. Create an Elasticsearch Serverless instance at [cloud.elastic.co](https://cloud.elastic.co/)
 2. Configure the API key with the following privileges:
 
+
 ```json
 {
-  "read-only-role": {
+  "ingestion": {
     "cluster": [
-      "manage"
+      "monitor", "manage"
     ],
     "indices": [
       {
         "names": [
-          "*"
+          "properties", "properties_raw"
         ],
         "privileges": [
-          "read"
+          "all"
         ],
         "allow_restricted_indices": false
       }
@@ -67,9 +68,11 @@ data-ingestion/
 }
 ```
 
-> **Note**: This API key configuration is for demo purposes only. In a production environment, you should follow proper security practices and limit the privileges to only what's necessary.
+> **Note**: This API key configuration is for demo purposes only. In a production environment, you should follow proper security practices and limit the privileges to only what's necessary.  The main README in the source of this project has an example read-only setting to use after ingestion is complete.
 
 ## Setup
+
+From a commandline terminal inside the ```data-ingestion``` folder:
 
 1. Make the setup script executable:
 ```bash
@@ -91,7 +94,7 @@ This will:
 
 The script uses the environment variables from the parent folder's `env_config.sh`. You can either:
 
-1. Use the existing configuration:
+1. Use an existing configuration:
 ```bash
 source ../env_config.sh
 ```

--- a/data-ingestion/ingest-properties.py
+++ b/data-ingestion/ingest-properties.py
@@ -15,8 +15,8 @@ DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')
 os.makedirs(DATA_DIR, exist_ok=True)
 
 # Elasticsearch Configurations
-ELASTIC_SERVERLESS_CLOUD_ID = os.getenv('ELASTIC_SERVERLESS_CLOUD_ID')
-ELASTIC_SERVERLESS_API_KEY = os.getenv('ELASTIC_SERVERLESS_API_KEY')
+ES_URL = os.getenv('ES_URL' ) ## expects full URL including scheme (http/https) and port (:443) 
+ES_API_KEY = os.getenv('ES_API_KEY')
 
 # Constants
 RAW_INDEX_NAME = "properties_raw"
@@ -27,7 +27,9 @@ PROPERTIES_FILE = os.path.join(DATA_DIR, "properties.json")
 ELSER_INFERENCE_ID = ".elser-2-elasticsearch"
 
 # Connect to Elasticsearch
-es = Elasticsearch(cloud_id=ELASTIC_SERVERLESS_CLOUD_ID, api_key=ELASTIC_SERVERLESS_API_KEY, request_timeout=300)
+if not ES_URL or not ES_API_KEY:
+    raise ValueError("ES_URL and ES_API_KEY environment variables must be set")
+es = Elasticsearch(hosts=[ES_URL], api_key=ES_API_KEY, request_timeout=300)
 es.info()
 
 def create_raw_index():


### PR DESCRIPTION
I added some suggestions for  the ingestion API key privs vs. read only privs

I made the ingestion section use the same env names as the mcp server for Elasticsearch connection